### PR TITLE
feat(pre-commit): Let other repos run debtmap as a hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,30 @@
+# Hooks that other repositories can consume:
+#
+#   repos:
+#     - repo: https://github.com/iepathos/debtmap
+#       rev: v0.23.0
+#       hooks:
+#         - id: debtmap
+#
+# `debtmap` installs this repository at the pinned `rev`.
+# `debtmap-system` uses a `debtmap` binary already on PATH.
+
+- id: debtmap
+  name: debtmap
+  description: Validate the repository against configured debtmap quality gates
+  language: rust
+  entry: debtmap
+  args: [validate, .]
+  pass_filenames: false
+  require_serial: true
+  files: (\.debtmap\.toml$)|(\.(rs|py|js|jsx|ts|tsx|go|sol)$)
+
+- id: debtmap-system
+  name: debtmap (system)
+  description: Validate using a pre-installed debtmap binary on PATH
+  language: system
+  entry: debtmap
+  args: [validate, .]
+  pass_filenames: false
+  require_serial: true
+  files: (\.debtmap\.toml$)|(\.(rs|py|js|jsx|ts|tsx|go|sol)$)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ jobs:
           fail-on-violation: 'true'
 ```
 
+## Pre-commit
+
+Add Debtmap to `.pre-commit-config.yaml` to fail commits that exceed your quality gates:
+
+```yaml
+repos:
+  - repo: https://github.com/iepathos/debtmap
+    rev: v0.23.0  # pin a released tag
+    hooks:
+      - id: debtmap
+```
+
+This runs `debtmap validate .` using the version pinned by `rev`. Configure thresholds in `.debtmap.toml` (`debtmap init`). The first install compiles Debtmap from source and needs a Rust toolchain.
+
+To use a `debtmap` binary already on your `PATH` instead of compiling from the pinned revision:
+
+```yaml
+      - id: debtmap-system
+```
+
+Override the default arguments when you need extra flags:
+
+```yaml
+      - id: debtmap
+        args: [validate, ., --max-debt-density, "30"]
+```
+
 ## Documentation
 
 **[Full Documentation](https://iepathos.github.io/debtmap/)** — guides, examples, configuration reference

--- a/book/src/validation-gates.md
+++ b/book/src/validation-gates.md
@@ -18,6 +18,7 @@ The `validate` command enforces quality gates in your development workflow, maki
 - [Migrating from Deprecated Thresholds](#migrating-from-deprecated-thresholds)
 - [Troubleshooting](#troubleshooting)
 - [Best Practices](#best-practices)
+  - [Pre-Commit Hook Integration](#pre-commit-hook-integration)
 
 ## Validate vs Analyze
 
@@ -869,7 +870,38 @@ min_coverage_percentage = 50.0
 
 ### Pre-Commit Hook Integration
 
-Add validation as a pre-commit hook:
+The recommended setup is [pre-commit](https://pre-commit.com/). Add Debtmap to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/iepathos/debtmap
+    rev: v0.23.0  # pin a released tag
+    hooks:
+      - id: debtmap
+```
+
+This runs `debtmap validate .` and fails the commit when quality gates are exceeded. Thresholds come from `.debtmap.toml` (`debtmap init`) or from hook `args`.
+
+The `debtmap` hook compiles this repository at the pinned `rev` and requires a Rust toolchain. Use `debtmap-system` if `debtmap` is already installed on `PATH`:
+
+```yaml
+      - id: debtmap-system
+```
+
+Override arguments to pass extra flags (replacing the defaults):
+
+```yaml
+      - id: debtmap
+        args: [validate, ., -v, --max-debt-density, "30"]
+```
+
+Install the git hook after editing the config:
+
+```bash
+pre-commit install
+```
+
+Alternatively, use a raw git hook that calls an already-installed binary:
 
 ```bash
 # .git/hooks/pre-commit

--- a/tests/documentation_contract_test.rs
+++ b/tests/documentation_contract_test.rs
@@ -47,3 +47,26 @@ fn public_docs_describe_current_language_and_output_contracts() {
     assert!(getting_started.contains("Solidity `.sol`"));
     assert!(!architecture.contains("focused exclusively on Rust"));
 }
+
+#[test]
+fn pre_commit_hooks_manifest_exposes_validate_hooks() {
+    let manifest = include_str!("../.pre-commit-hooks.yaml");
+    assert!(manifest.contains("id: debtmap\n"));
+    assert!(manifest.contains("id: debtmap-system\n"));
+    assert!(manifest.contains("language: rust"));
+    assert!(manifest.contains("language: system"));
+    assert!(manifest.contains("entry: debtmap"));
+    assert!(manifest.contains("pass_filenames: false"));
+    assert!(manifest.contains("validate"));
+}
+
+#[test]
+fn public_docs_describe_pre_commit_consumption() {
+    let readme = include_str!("../README.md");
+    let validation_gates = include_str!("../book/src/validation-gates.md");
+    assert!(readme.contains("repo: https://github.com/iepathos/debtmap"));
+    assert!(readme.contains("id: debtmap"));
+    assert!(readme.contains("id: debtmap-system"));
+    assert!(validation_gates.contains(".pre-commit-config.yaml"));
+    assert!(validation_gates.contains("id: debtmap"));
+}


### PR DESCRIPTION
## Summary
- Add `.pre-commit-hooks.yaml` so other repositories can pin this repo and run `debtmap validate` from `.pre-commit-config.yaml`.
- Provide a `debtmap` hook that compiles the pinned revision, plus `debtmap-system` for an already-installed binary.
- Document consumer setup in the README and validation-gates guide, with contract tests for the manifest and docs.

## Test plan
- [ ] Confirm `.pre-commit-hooks.yaml` is valid (`pre-commit validate-manifest` or YAML parse).
- [ ] In a throwaway repo, add:
  ```yaml
  repos:
    - repo: https://github.com/iepathos/debtmap
      rev: <this-branch-or-tag>
      hooks:
        - id: debtmap
  ```
  then run `pre-commit install` and `pre-commit run debtmap --all-files`.
- [ ] Verify the hook fails when quality gates are exceeded and passes when they are not.
- [ ] Verify `args` overrides work, e.g. `args: [validate, ., --max-debt-density, "30"]`.
- [ ] Run `cargo test --test documentation_contract_test`.


Made with [Cursor](https://cursor.com)